### PR TITLE
Rename whole project to a more semantic (and boring) name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,33 +3,33 @@
 version = 3
 
 [[package]]
-name = "antlion"
-version = "0.3.2"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
+name = "reflexive"
+version = "0.4.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,10 @@ authors = ["Yvan Sraka <yvan@sraka.xyz>"]
 description = "Handy way to evaluate at compile-time any Rust expression"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-name = "antlion"
-repository = "https://github.com/yvan-sraka/antlion"
+name = "reflexive"
+repository = "https://github.com/yvan-sraka/reflexive"
 rust-version = "1.56.1"
-version = "0.3.2"
+version = "0.4.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- cargo-sync-readme start -->
 
-# `antlion`
+# `reflexive`
 
 A magical _meta_ function that evaluate (at compile-time if used inside a
 macro which is the point of taking a `TokenStream` input) any Rust expr!
@@ -8,7 +8,7 @@ macro which is the point of taking a `TokenStream` input) any Rust expr!
 ## Example
 
 ```rust
-use antlion::Sandbox;
+use reflexive::Sandbox;
 use quote::quote;
 
 let test = Sandbox::new("calc").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! # `antlion`
+//! # `reflexive`
 //!
 //! A magical _meta_ function that evaluate (at compile-time if used inside a
 //! macro which is the point of taking a `TokenStream` input) any Rust expr!
@@ -6,7 +6,7 @@
 //! ## Example
 //!
 //! ```rust
-//! use antlion::Sandbox;
+//! use reflexive::Sandbox;
 //! use quote::quote;
 //!
 //! let test = Sandbox::new("calc").unwrap();


### PR DESCRIPTION
While `antlion` is a quirky codename stemming from my personal secret passion for entomology, it may not convey the project's purpose to a wider audience.

The project was primarily created to enhance `hs-bindgen` with the capability of evaluating Rust code at macro-expansion time. However, as `cargo-cabal` has steadily grown in popularity among users and even contributors, I've considered whether it would be beneficial to give this project a more descriptive name, potentially encouraging more users to find it through [crates.io search](https://crates.io/search?q=reflexive).